### PR TITLE
espidf framework build fixes

### DIFF
--- a/src/roo_io/fs/esp32/esp-idf/sdmmc.cpp
+++ b/src/roo_io/fs/esp32/esp-idf/sdmmc.cpp
@@ -20,6 +20,7 @@
 
 #include "diskio_sdmmc.h"
 #include "driver/sdmmc_host.h"
+#include "esp_idf_version.h"
 #include "esp_vfs_fat.h"
 #include "roo_io/fs/posix/posix_mount.h"
 #include "roo_logging.h"
@@ -72,12 +73,16 @@ MountImpl::MountResult SdMmcFs::mountImpl(std::function<void()> unmount_fn) {
 
   sdmmc_slot_config_t slot_config = SDMMC_SLOT_CONFIG_DEFAULT();
   if (!use_default_pins_) {
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
     slot_config.clk = pin_clk_;
     slot_config.cmd = pin_cmd_;
     slot_config.d0 = pin_d0_;
     slot_config.d1 = pin_d1_;
     slot_config.d2 = pin_d2_;
     slot_config.d3 = pin_d3_;
+#else
+    LOG(WARNING) << "Custom SDMMC pins not supported on ESP-IDF < 5.0";
+#endif
     slot_config.width = width_;
   }
   esp_vfs_fat_sdmmc_mount_config_t mount_config = {

--- a/src/roo_io/fs/fsutil.cpp
+++ b/src/roo_io/fs/fsutil.cpp
@@ -1,5 +1,7 @@
 #include "roo_io/fs/fsutil.h"
 
+#include <cstring>
+
 namespace roo_io {
 
 namespace {
@@ -39,7 +41,9 @@ Status MkDirRecursively(roo_io::Mount& fs, const char* path) {
   }
   if (stat.status() != kNotFound) return stat.status();
 
-  std::unique_ptr<char[]> path_copy(strdup(path));
+  auto len = std::strlen(path) + 1;
+  std::unique_ptr<char[]> path_copy(new char[len]);
+  std::memcpy(path_copy.get(), path, len);
   char* p = path_copy.get();
   while (true) {
     while (*p == '/') ++p;
@@ -63,7 +67,9 @@ Status MkParentDirRecursively(roo_io::Mount& fs, const char* path) {
   }
   if (stat.status() != kNotFound) return stat.status();
 
-  std::unique_ptr<char[]> path_copy(strdup(path));
+  auto len = std::strlen(path) + 1;
+  std::unique_ptr<char[]> path_copy(new char[len]);
+  std::memcpy(path_copy.get(), path, len);
   char* p = path_copy.get();
   while (true) {
     while (*p == '/') ++p;

--- a/src/roo_io/third_party/endianness.h
+++ b/src/roo_io/third_party/endianness.h
@@ -77,7 +77,7 @@
 #  define bswap16(x)     _byteswap_ushort((x))
 #  define bswap32(x)     _byteswap_ulong((x))
 #  define bswap64(x)     _byteswap_uint64((x))
-#elif defined(ESP32) && !defined(__linux__) // endian.h already defines these.
+#elif (defined(ESP_PLATFORM) || defined(IDF_VER)) && !defined(__linux__) // ESP-IDF's endian.h already defines these.
 #elif (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
 #  define bswap16(x)     __builtin_bswap16((x))
 #  define bswap32(x)     __builtin_bswap32((x))


### PR DESCRIPTION
- fix for "error: 'operator delete[]' called on pointer returned from a mismatched allocation function
- fix for redefinition of bswapXX in espidf
- fix for build error in sdmmc_slot_config_t pin config in esp-idf < 5.0.0