### PR TITLE
fix for "missing initializer" error

### DIFF
--- a/src/roo_io/fs/esp32/esp-idf/sdmmc.cpp
+++ b/src/roo_io/fs/esp32/esp-idf/sdmmc.cpp
@@ -85,10 +85,10 @@ MountImpl::MountResult SdMmcFs::mountImpl(std::function<void()> unmount_fn) {
 #endif
     slot_config.width = width_;
   }
-  esp_vfs_fat_sdmmc_mount_config_t mount_config = {
-      .format_if_mount_failed = formatIfMountFailed(),
-      .max_files = maxOpenFiles(),
-      .allocation_unit_size = 16 * 1024};
+  esp_vfs_fat_sdmmc_mount_config_t mount_config = {};
+  mount_config.format_if_mount_failed = formatIfMountFailed();
+  mount_config.max_files = maxOpenFiles();
+  mount_config.allocation_unit_size = 16 * 1024;
 
   esp_err_t ret = esp_vfs_fat_sdmmc_mount(mount_base_path_.c_str(), &host,
                                           &slot_config, &mount_config, &card_);

--- a/src/roo_io/fs/esp32/esp-idf/sdspi.cpp
+++ b/src/roo_io/fs/esp32/esp-idf/sdspi.cpp
@@ -50,10 +50,11 @@ MountImpl::MountResult SdSpiFs::mountImpl(std::function<void()> unmount_fn) {
   dev_config.host_id = spi_host_;
   dev_config.gpio_cs = cs_pin_;
 
-  esp_vfs_fat_mount_config_t mount_config = {
-      .format_if_mount_failed = formatIfMountFailed(),
-      .max_files = maxOpenFiles(),
-      .allocation_unit_size = 16 * 1024};
+  esp_vfs_fat_mount_config_t mount_config = {};
+  mount_config.format_if_mount_failed = formatIfMountFailed(),
+  mount_config.max_files = maxOpenFiles(),
+  mount_config.allocation_unit_size = 16 * 1024;
+
   if (checkMediaPresence() == kMediaAbsent) {
     return MountImpl::MountError(kNoMedia);
   }


### PR DESCRIPTION
Fix for espidf build errors.
recently PIO's espressif32 package was updated and "platform = espressif32" is now using 7.0.1 version which is based on "ESP-IDF v6.0.1"
actually this has impact on all roo_* libraries...